### PR TITLE
Fix loading a stylesheet on root of an HTML Import

### DIFF
--- a/src/KitchenSink/wwwroot/KitchenSink/MasterPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/MasterPage.html
@@ -1,5 +1,5 @@
-﻿<link rel="stylesheet" href="/KitchenSink/style.css">
-<template>
+﻿<template>
+    <link rel="stylesheet" href="/KitchenSink/style.css">
     <template id="root" is="dom-bind">
         <starcounter-include slot="kitchensink/nav" partial="{{model.NavPage}}"></starcounter-include>
         <starcounter-include slot="kitchensink/current" partial="{{model.CurrentPage}}"></starcounter-include>

--- a/src/KitchenSink/wwwroot/KitchenSink/MasterPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/MasterPage.html
@@ -1,5 +1,13 @@
-﻿<template>
-    <link rel="stylesheet" href="/KitchenSink/style.css">
+﻿<link rel="stylesheet" href="/KitchenSink/style.css">
+<script>
+(function(){
+    var importDoc = document.currentScript.ownerDocument;
+    var elem = importDoc.querySelector("link[rel='stylesheet']")
+    document.head.appendChild(elem);        
+})();
+</script>
+
+<template>
     <template id="root" is="dom-bind">
         <starcounter-include slot="kitchensink/nav" partial="{{model.NavPage}}"></starcounter-include>
         <starcounter-include slot="kitchensink/current" partial="{{model.CurrentPage}}"></starcounter-include>


### PR DESCRIPTION
Problem: Loading a stylesheet on root of an HTML Import to display a warning (https://github.com/Starcounter/RebelsLounge/issues/222)

Solution: move loading of the stylesheet to the stamped template