### PR TITLE
Fix for firefox failing tests on SC 2.4

### DIFF
--- a/src/KitchenSink/wwwroot/sys/pikaday-decorator/.bower.json
+++ b/src/KitchenSink/wwwroot/sys/pikaday-decorator/.bower.json
@@ -37,6 +37,6 @@
     "commit": "f768b99657cf71f938c075c86d930007e9c5c208"
   },
   "_source": "https://github.com/display-interactive/pikaday-decorator.git",
-  "_target": "*",
+  "_target": "^0.9.0",
   "_originalSource": "pikaday-decorator"
 }

--- a/test/KitchenSink.Tests/Ui/BasePage.cs
+++ b/test/KitchenSink.Tests/Ui/BasePage.cs
@@ -114,13 +114,13 @@ namespace KitchenSink.Tests.Ui
             return scriptResult;
         }
 
-        public IWebElement GetElementByQuerySelector(By elementSelector, string queryArgument)
+        public IWebElement GetShadowElementByQuerySelector(By elementSelector, string queryArgument)
         {
             var shadowRootElement = Driver.FindElement(elementSelector);
-            return GetElementByQuerySelector(shadowRootElement, queryArgument);
+            return GetShadowElementByQuerySelector(shadowRootElement, queryArgument);
         }
 
-        public IWebElement GetElementByQuerySelector(IWebElement shadowRootElement, string queryArgument)
+        public IWebElement GetShadowElementByQuerySelector(IWebElement shadowRootElement, string queryArgument)
         {
             var script = $"return arguments[0].shadowRoot.querySelector('{queryArgument}')";
             var webElement = (IWebElement)ExecuteScriptOnElement(shadowRootElement, script);

--- a/test/KitchenSink.Tests/Ui/BasePage.cs
+++ b/test/KitchenSink.Tests/Ui/BasePage.cs
@@ -106,16 +106,26 @@ namespace KitchenSink.Tests.Ui
             element.Click();
         }
 
-        public IWebElement ExpandShadowRoot(IWebElement shadowRootElement)
+        public object ExecuteScriptOnElement(IWebElement shadowRootElement, string script)
         {
-            IWebElement shadowTreeParent = (IWebElement)((IJavaScriptExecutor)Driver)
-           .ExecuteScript("return arguments[0].shadowRoot", shadowRootElement);
-            if (shadowTreeParent == null)
-            {
-                //Shadow DOM not supported, fall back to DOM
-                return shadowRootElement;
-            }
-            return shadowTreeParent;
+            var scriptResult = ((IJavaScriptExecutor)Driver)
+                .ExecuteScript(script, shadowRootElement);
+
+            return scriptResult;
+        }
+
+        public IWebElement GetElementByQuerySelector(By elementSelector, string queryArgument)
+        {
+            var shadowRootElement = Driver.FindElement(elementSelector);
+            return GetElementByQuerySelector(shadowRootElement, queryArgument);
+        }
+
+        public IWebElement GetElementByQuerySelector(IWebElement shadowRootElement, string queryArgument)
+        {
+            var script = $"return arguments[0].shadowRoot.querySelector('{queryArgument}')";
+            var webElement = (IWebElement)ExecuteScriptOnElement(shadowRootElement, script);
+
+            return webElement;
         }
 
         public void ScrollToTheTop()

--- a/test/KitchenSink.Tests/Ui/DatagridPage.cs
+++ b/test/KitchenSink.Tests/Ui/DatagridPage.cs
@@ -50,7 +50,7 @@ namespace KitchenSink.Tests.Ui
         {
             var td = GetCellsByText(searchText).First();
             DblClickOn(td);
-            var input = GetElementByQuerySelector(By.XPath("//hot-table"), "textarea.handsontableInput");
+            var input = GetShadowElementByQuerySelector(By.XPath("//hot-table"), "textarea.handsontableInput");
             input.Clear();
             input.SendKeys(newText);
             input.SendKeys(Keys.Enter);
@@ -63,7 +63,7 @@ namespace KitchenSink.Tests.Ui
 
         private IWebElement GetHtCore()
         {
-            return GetElementByQuerySelector(By.XPath("//hot-table"), ".htCore");
+            return GetShadowElementByQuerySelector(By.XPath("//hot-table"), ".htCore");
         }
     }
 }

--- a/test/KitchenSink.Tests/Ui/DatagridPage.cs
+++ b/test/KitchenSink.Tests/Ui/DatagridPage.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.PageObjects;
 using System.Linq;
@@ -17,22 +18,22 @@ namespace KitchenSink.Tests.Ui
 
         public bool CheckTableVisible()
         {
-            return GetHotTableShadowRoot().FindElement(By.ClassName("htCore")).Displayed;
+            bool isHotTableVisible = GetHtCore().Displayed;
+
+            return isHotTableVisible;
         }
 
-        public int GetTableRowsCount()
+        public long GetTableRowsCount()
         {
-            return GetHotTableShadowRoot().FindElement(By.ClassName("htCore")).FindElements(By.XPath("tbody//tr")).Count;
-        }
+            var tableRowsCount = GetHtCore().FindElements(By.XPath("tbody//tr")).Count;
 
-        public IWebElement GetHotTableShadowRoot()
-        {
-            return ExpandShadowRoot(Driver.FindElement(By.XPath("//hot-table")));
+            return tableRowsCount;
         }
 
         public IReadOnlyCollection<IWebElement> GetCellsByText(string searchText)
         {
-            return GetHotTableShadowRoot().FindElement(By.ClassName("htCore")).FindElements(By.XPath($"tbody//tr//td[text() = '{searchText}']"));
+            var cells = GetHtCore().FindElements(By.XPath($"tbody//tr//td[text() = '{searchText}']"));
+            return cells;
         }
 
         public int GetCatsCount()
@@ -49,7 +50,7 @@ namespace KitchenSink.Tests.Ui
         {
             var td = GetCellsByText(searchText).First();
             DblClickOn(td);
-            var input = GetHotTableShadowRoot().FindElement(By.CssSelector("textarea.handsontableInput"));
+            var input = GetElementByQuerySelector(By.XPath("//hot-table"), "textarea.handsontableInput");
             input.Clear();
             input.SendKeys(newText);
             input.SendKeys(Keys.Enter);
@@ -58,6 +59,11 @@ namespace KitchenSink.Tests.Ui
         public void AddPet()
         {
             ClickOn(AddPetButton);
+        }
+
+        private IWebElement GetHtCore()
+        {
+            return GetElementByQuerySelector(By.XPath("//hot-table"), ".htCore");
         }
     }
 }

--- a/test/KitchenSink.Tests/Ui/FileUploadPage.cs
+++ b/test/KitchenSink.Tests/Ui/FileUploadPage.cs
@@ -22,8 +22,7 @@ namespace KitchenSink.Tests.Ui
 
         public void UploadAFile(string filePath)
         {
-            var shadowRoot = ExpandShadowRoot(Driver.FindElement(By.XPath("//starcounter-upload")));
-            shadowRoot.FindElement(By.Id("fileElement")).SendKeys(filePath);
+            GetFileElement().SendKeys(filePath);
         }
 
         public int GetUploadedFilesCount()
@@ -33,8 +32,7 @@ namespace KitchenSink.Tests.Ui
 
         public bool CheckFileInputVisible()
         {
-            var shadowRoot = ExpandShadowRoot(Driver.FindElement(By.XPath("//starcounter-upload")));
-            return shadowRoot.FindElement(By.Id("fileElement")).Enabled;
+            return GetFileElement().Enabled;
         }
 
         public void DeleteAllFiles()
@@ -44,5 +42,11 @@ namespace KitchenSink.Tests.Ui
                 ClickOn(deleteButton);
             }
         }
+
+        private IWebElement GetFileElement()
+        {
+            return GetElementByQuerySelector(By.XPath("//starcounter-upload"), "#fileElement");
+        }
+
     }
 }

--- a/test/KitchenSink.Tests/Ui/FileUploadPage.cs
+++ b/test/KitchenSink.Tests/Ui/FileUploadPage.cs
@@ -45,7 +45,7 @@ namespace KitchenSink.Tests.Ui
 
         private IWebElement GetFileElement()
         {
-            return GetElementByQuerySelector(By.XPath("//starcounter-upload"), "#fileElement");
+            return GetShadowElementByQuerySelector(By.XPath("//starcounter-upload"), "#fileElement");
         }
 
     }

--- a/test/KitchenSink.Tests/Ui/MarkdownPage.cs
+++ b/test/KitchenSink.Tests/Ui/MarkdownPage.cs
@@ -20,8 +20,12 @@ namespace KitchenSink.Tests.Ui
 
         public string GetHeaderText()
         {
-            var shadowRoot = ExpandShadowRoot(Driver.FindElement(By.TagName("juicy-markdown"))); 
-            return shadowRoot.FindElement(By.TagName("h1")).Text; //BUG in CHROME b.getElementsByTagName is not a function
+            return GetJuicyMarkdown().Text;
+        }
+
+        private IWebElement GetJuicyMarkdown()
+        {
+            return GetElementByQuerySelector(By.TagName("juicy-markdown"), "h1");
         }
     }
 }

--- a/test/KitchenSink.Tests/Ui/MarkdownPage.cs
+++ b/test/KitchenSink.Tests/Ui/MarkdownPage.cs
@@ -25,7 +25,7 @@ namespace KitchenSink.Tests.Ui
 
         private IWebElement GetJuicyMarkdown()
         {
-            return GetElementByQuerySelector(By.TagName("juicy-markdown"), "h1");
+            return GetShadowElementByQuerySelector(By.TagName("juicy-markdown"), "h1");
         }
     }
 }

--- a/test/KitchenSink.Tests/Ui/TextPage.cs
+++ b/test/KitchenSink.Tests/Ui/TextPage.cs
@@ -54,12 +54,12 @@ namespace KitchenSink.Tests.Ui
 
         public IWebElement GetInputForPaperElement(IWebElement paperInput)
         {
-            return GetElementByQuerySelector(paperInput, "input");
+            return GetShadowElementByQuerySelector(paperInput, "input");
         }
 
         public IWebElement GetPaperInput(IWebElement paperElement, string id)
         {
-            return GetElementByQuerySelector(paperElement, $"#{id}");
+            return GetShadowElementByQuerySelector(paperElement, $"#{id}");
         }
     }
 }

--- a/test/KitchenSink.Tests/Ui/TextPage.cs
+++ b/test/KitchenSink.Tests/Ui/TextPage.cs
@@ -28,9 +28,9 @@ namespace KitchenSink.Tests.Ui
         public IWebElement PaperInputDynamic => Driver.FindElement(
             By.XPath("//paper-input[contains(@class, \"kitchensink-test-name-paper-input-dynamic\")]"));
 
-        public IWebElement PaperInputInfoLabel => ExpandShadowRoot(PaperInput).FindElement(By.Id("paper-input-label-1"));
+        public IWebElement PaperInputInfoLabel => GetPaperInput(PaperInput, "paper-input-label-1");
 
-        public IWebElement PaperInputDynamicInfoLabel => ExpandShadowRoot(PaperInputDynamic).FindElement(By.Id("paper-input-label-2"));
+        public IWebElement PaperInputDynamicInfoLabel => GetPaperInput(PaperInputDynamic, "paper-input-label-2");
 
 
         public void FillInput(IWebElement inputElement, string input)
@@ -54,14 +54,12 @@ namespace KitchenSink.Tests.Ui
 
         public IWebElement GetInputForPaperElement(IWebElement paperInput)
         {
-            return ExpandShadowRoot(paperInput).FindElement(By.CssSelector("input"));
+            return GetElementByQuerySelector(paperInput, "input");
         }
 
-        public IWebElement GetLabelForPaperElement(IWebElement paperElement)
+        public IWebElement GetPaperInput(IWebElement paperElement, string id)
         {
-            var shadowRoot = ExpandShadowRoot(paperElement);
-            var content = ExpandShadowRoot(shadowRoot);
-            return content.FindElement(By.XPath("//label"));
+            return GetElementByQuerySelector(paperElement, $"#{id}");
         }
     }
 }


### PR DESCRIPTION
Right now, there are many tests that fail because of `InternalError: Too much recursion`. It's caused by a bug in geckodriver (https://github.com/mozilla/geckodriver/issues/904). This fix should prevent that from happening. If it passes the review, It should be applied in all apps that have selenium tests with `ExecuteScript("return arguments[0].shadowRoot", shadowRootElement);` usage.