### PR TITLE
Problem #239: Async response - Client side messages don't work

### DIFF
--- a/src/KitchenSink/CallbackPage.json
+++ b/src/KitchenSink/CallbackPage.json
@@ -5,15 +5,13 @@
   "SaveAndMessageTrigger$": 0,
   "SuccessMessage$": "",
   "ErrorMessage$": "",
-  "SaveAndClientMessageTrigger$": 0,
   "Items": [
     {
       "SaveTrigger$": 0,
       "SaveAndSpinTrigger$": 0,
       "SaveAndMessageTrigger$": 0,
       "SuccessMessage$": "",
-      "ErrorMessage$": "",
-      "SaveAndClientMessageTrigger$": 0
+      "ErrorMessage$": ""
     }
   ]
 }

--- a/src/KitchenSink/CallbackPage.json.cs
+++ b/src/KitchenSink/CallbackPage.json.cs
@@ -39,11 +39,11 @@ namespace KitchenSink
 
             if (DateTime.Now.Ticks%2 == 0)
             {
-                this.SuccessMessage = "The changes are successfully saved";
+                this.SuccessMessage = "This is a random success alert from the server";
             }
             else
             {
-                this.ErrorMessage = "Failed to save changes";
+                this.ErrorMessage = "This is a random danger alert from the server";
             }
         }
 

--- a/src/KitchenSink/CallbackPage.json.cs
+++ b/src/KitchenSink/CallbackPage.json.cs
@@ -47,12 +47,6 @@ namespace KitchenSink
             }
         }
 
-        protected void Handle(Input.SaveAndClientMessageTrigger Action)
-        {
-            Action.Cancel();
-            System.Threading.Thread.CurrentThread.Join(timeout);
-        }
-
         [CallbackPage_json.Items]
         partial class CallbackPageItem
         {
@@ -86,12 +80,6 @@ namespace KitchenSink
                 {
                     this.ErrorMessage = "Failed to save changes";
                 }
-            }
-
-            protected void Handle(Input.SaveAndClientMessageTrigger Action)
-            {
-                Action.Cancel();
-                System.Threading.Thread.CurrentThread.Join(timeout);
             }
         }
     }

--- a/src/KitchenSink/wwwroot/KitchenSink/CallbackPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/CallbackPage.html
@@ -4,10 +4,13 @@
             <h1 slot="kitchensink/callback-heading">Async Response</h1>
 
             <p slot="kitchensink/callback-description">
-                This page demonstrates how to achive old fassion <code>callback</code> behaviour using Starcounter.
+                This page demonstrates how to receive and render an async response from the server.
             </p>
 
-            <h2 slot="kitchensink/callback-responsive-label">Responsive save button</h2>
+            <h2 slot="kitchensink/callback-responsive-heading">Async save button</h2>
+
+            <p slot="kitchensink/callback-responsive-text">These buttons go into a <code>disabled</code> state until an updated status is pushed from the server</p>
+
             <button slot="kitchensink/callback-responsive-button" type="button" value="{{model.SaveTrigger$::click}}" disabled="{{model.SaveTrigger$}}" onmouseup="++this.value;">Save changes (1s)</button>
             <button slot="kitchensink/callback-responsive-button-spin" type="button" value="{{model.SaveAndSpinTrigger$::click}}" disabled="{{model.SaveAndSpinTrigger$}}" onmouseup="++this.value;">
                 <template is="dom-if" if="{{model.SaveAndSpinTrigger$}}">
@@ -16,70 +19,20 @@
                     </svg>
                     </i>
                 </template>
-                Save changes with loading icon (1s)
+                Save changes with loading indicator (1s)
             </button>
 
-            <h2 slot="kitchensink/callback-save-server-heading">Save button with server side message</h2>
+            <h2 slot="kitchensink/callback-save-server-heading">Message from the server</h2>
+
+            <p slot="kitchensink/callback-save-server-text">These buttons go into a <code>disabled</code> state until an updated status and a message is pushed from the server</p>
+
             <template is="dom-if" if="{{model.SuccessMessage$}}">
                 <p slot="kitchensink/callback-save-server-success-message">{{model.SuccessMessage$}}</p>
             </template>
             <template is="dom-if" if="{{model.ErrorMessage$}}">
                 <p slot="kitchensink/callback-save-server-danger-message">{{model.ErrorMessage$}}</p>
             </template>
-            <button slot="kitchensink/callback-save-server-button" type="button" value="{{model.SaveAndMessageTrigger$::click}}" disabled="{{model.SaveAndMessageTrigger$}}" onmouseup="++this.value;">Randomly save or fail changes (1s)</button>
-
-            <h2 slot="kitchensink/callback-table-heading">Same things inside table</h2>
-            <p slot="kitchensink/callback-table-note">
-                <small><b>Note:</b> <code>dom-repeat</code> inside <code>table</code> <a href="https://github.com/Polymer/polymer/issues/1567" target="_blank">does not work in Internet Explorer</a>.</small>
-            </p>
-            <table slot="kitchensink/callback-table">
-                <thead>
-                    <tr>
-                        <th rowspan="2">#</th>
-                        <th>Message</th>
-                        <th colspan="2">Responsive button</th>
-                        <th>With message</th>
-                    </tr>
-                    <tr>
-                        <th>Server</th>
-                        <th>Simple</th>
-                        <th>Loading icon</th>
-                        <th>Server</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <template is="dom-repeat" items="{{model.Items}}">
-                        <tr>
-                            <td>{{index}}</td>
-                            <td>
-                                <template is="dom-if" if="{{item.SuccessMessage$}}">
-                                    <span>{{item.SuccessMessage$}}</span>
-                                </template>
-                                <template is="dom-if" if="{{item.ErrorMessage$}}">
-                                    <span>{{item.ErrorMessage$}}</span>
-                                </template>
-                            </td>
-                            <td>
-                                <button type="button" value="{{item.SaveTrigger$::click}}" disabled="{{item.SaveTrigger$}}" onmouseup="++this.value;">Save</button>
-                            </td>
-                            <td>
-                                <button type="button" value="{{item.SaveAndSpinTrigger$::click}}" disabled="{{item.SaveAndSpinTrigger$}}" onmouseup="++this.value;">
-                                    <template is="dom-if" if="{{item.SaveAndSpinTrigger$}}">
-                                        <i class="kitchen-sink-spinner">
-                                            <svg height="14px" style="enable-background: new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="14px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M28,16c-1.219,0-1.797,0.859-2,1.766C25.269,21.03,22.167,26,16,26c-5.523,0-10-4.478-10-10S10.477,6,16,6  c2.24,0,4.295,0.753,5.96,2H20c-1.104,0-2,0.896-2,2s0.896,2,2,2h6c1.104,0,2-0.896,2-2V4c0-1.104-0.896-2-2-2s-2,0.896-2,2v0.518  C21.733,2.932,18.977,2,16,2C8.268,2,2,8.268,2,16s6.268,14,14,14c9.979,0,14-9.5,14-11.875C30,16.672,28.938,16,28,16z"></path>
-                                    </svg>
-                                        </i>
-                                    </template>
-                                    Save with icon
-                                </button>
-                            </td>
-                            <td>
-                                <button type="button" value="{{item.SaveAndMessageTrigger$::click}}" disabled="{{item.SaveAndMessageTrigger$}}" onmouseup="++this.value;">Save</button>
-                            </td>
-                        </tr>
-                    </template>
-                </tbody>
-            </table>
+            <button slot="kitchensink/callback-save-server-button" type="button" value="{{model.SaveAndMessageTrigger$::click}}" disabled="{{model.SaveAndMessageTrigger$}}" onmouseup="++this.value;">Save and get message (1s)</button>
         </template>
     </dom-bind>
     <template is="declarative-shadow-dom">
@@ -88,12 +41,14 @@
         </style>
         <slot name="kitchensink/callback-heading"></slot>
         <slot name="kitchensink/callback-description"></slot>
-        <slot name="kitchensink/callback-responsive-label"></slot>
+        <slot name="kitchensink/callback-responsive-heading"></slot>
+        <slot name="kitchensink/callback-responsive-text"></slot>
         <div>
             <slot name="kitchensink/callback-responsive-button"></slot>
             <slot name="kitchensink/callback-responsive-button-spin"></slot>
         </div>
         <slot name="kitchensink/callback-save-server-heading"></slot>
+        <slot name="kitchensink/callback-save-server-text"></slot>
         <div class="uni-alert-success">
             <slot name="kitchensink/callback-save-server-success-message"></slot>
         </div>
@@ -101,8 +56,5 @@
             <slot name="kitchensink/callback-save-server-danger-message"></slot>
         </div>
         <slot name="kitchensink/callback-save-server-button"></slot>
-        <slot name="kitchensink/callback-table-heading"></slot>
-        <slot name="kitchensink/callback-table-note"></slot>
-        <slot name="kitchensink/callback-table"></slot>
     </template>
 </template>

--- a/src/KitchenSink/wwwroot/KitchenSink/CallbackPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/CallbackPage.html
@@ -25,23 +25,6 @@
             </template>
         </div>
         <button slot="kitchensink/callback-save-server-button" type="button" class="btn btn-sm btn-default" value="{{model.SaveAndMessageTrigger$::click}}" disabled="{{model.SaveAndMessageTrigger$}}" onmouseup="++this.value;">Randomly save or fail changes (1s)</button>
-        <h2 slot="kitchensink/callback-save-client-heading" class="kitchensink-heading-2">Save button with client side message</h2>
-        <p slot="kitchensink/callback-save-client-note">
-            <b>Note:</b> client side <code>template.observers</code> work only in browsers with native <code>&lt;template&gt;</code> tag implementation.
-        </p>
-        <div slot="kitchensink/callback-save-client-message">
-            <template is="dom-if" if="{{local.InfoMessage$}}">
-                <p class="alert alert-info">{{local.InfoMessage$}}</p>
-            </template>
-            <template is="dom-if" if="{{local.SuccessMessage$}}">
-                <p class="alert alert-success">{{local.SuccessMessage$}}</p>
-            </template>
-            <template is="dom-if" if="{{local.ErrorMessage$}}">
-                <p class="alert alert-danger">{{local.ErrorMessage$}}</p>
-            </template>
-        </div>
-
-        <button slot="kitchensink/callback-save-client-button" type="button" class="btn btn-sm btn-default" value="{{model.SaveAndClientMessageTrigger$::click}}" disabled="{{model.SaveAndClientMessageTrigger$}}" onmouseup="++this.value;">Randomly save or fail changes (1s)</button>
 
         <h2 slot="kitchensink/callback-table-heading" class="kitchensink-heading-2">Same things inside table</h2>
         <p slot="kitchensink/callback-table-note">
@@ -51,17 +34,15 @@
             <thead>
                 <tr>
                     <th rowspan="2">#</th>
-                    <th colspan="2">Message</th>
+                    <th>Message</th>
                     <th colspan="2">Responsive button</th>
-                    <th colspan="2">With message</th>
+                    <th>With message</th>
                 </tr>
                 <tr>
                     <th>Server</th>
-                    <th>Client</th>
                     <th>Simple</th>
                     <th>Loading icon</th>
                     <th>Server</th>
-                    <th>Client</th>
                 </tr>
             </thead>
             <tbody>
@@ -74,17 +55,6 @@
                             </template>
                             <template is="dom-if" if="{{item.ErrorMessage$}}">
                                 <span class="label label-danger">{{item.ErrorMessage$}}</span>
-                            </template>
-                        </td>
-                        <td>
-                            <template is="dom-if" if="{{item.local.InfoMessage$}}">
-                                <span class="label label-info">{{item.local.InfoMessage$}}</span>
-                            </template>
-                            <template is="dom-if" if="{{item.local.SuccessMessage$}}">
-                                <span class="label label-success">{{item.local.SuccessMessage$}}</span>
-                            </template>
-                            <template is="dom-if" if="{{item.local.ErrorMessage$}}">
-                                <span class="label label-danger">{{item.local.ErrorMessage$}}</span>
                             </template>
                         </td>
                         <td>
@@ -101,96 +71,11 @@
                         <td>
                             <button type="button" class="btn btn-xs btn-default" value="{{item.SaveAndMessageTrigger$::click}}" disabled="{{item.SaveAndMessageTrigger$}}" onmouseup="++this.value;">Save</button>
                         </td>
-                        <td>
-                            <button type="button" class="btn btn-xs btn-default" disabled="{{item.SaveAndClientMessageTrigger$}}" item="{{item}}" index="{{index}}" on-click="onItemSaveAndClientMessageClick">Save</button>
-                        </td>
                     </tr>
                 </template>
             </tbody>
         </table>
     </template></dom-bind>
-    <script>
-        (function () {
-            var script = document._currentScript || document.currentScript;
-            var template = Polymer.Element ? script.previousElementSibling : script.previousElementSibling.firstElementChild;
-
-            template.local = {
-                InfoMessage$: "",
-                SuccessMessage$: "",
-                ErrorMessage$: ""
-            };
-
-            template.observers = ["onSaveAndClientMessageClickChange(model.SaveAndClientMessageTrigger$)", "onItemChange(model.Items.*)"];
-
-            template.onSaveAndClientMessageClickChange = function (value) {
-                if (value) {
-                    // Button clicked, the value is greater than zero
-                    template.set("local.InfoMessage$", "Saving changes ...");
-                    template.set("local.SuccessMessage$", "");
-                    template.set("local.ErrorMessage$", "");
-                } else {
-                    // Received response from server and button's value reset
-                    template.set("local.InfoMessage$", "");
-
-                    if (new Date().getTime() % 2 == 0) {
-                        template.set("local.SuccessMessage$", "The changes are successfully saved");
-                    } else { 
-                        template.set("local.ErrorMessage$", "Failed to save changes");
-                    }
-                }
-            };
-
-            template.onItemChange = function (e) {
-                var path = e.path.split(".");
-                
-                if (path[path.length - 1] != "SaveAndClientMessageTrigger$") {
-                    return;
-                }
-
-                path.splice(-1);
-                path = path.join(".");
-
-                var item = template.get(path);
-                var value = e.value;
-
-                if (value) {
-                    // Button clicked, the value is greater than zero
-                    template.set(path + ".local.InfoMessage$", "Saving changes ...");
-                    template.set(path + ".local.SuccessMessage$", "");
-                    template.set(path + ".local.ErrorMessage$", "");
-                } else {
-                    // Received response from server and button's value reset
-                    template.set(path + ".local.InfoMessage$", "");
-
-                    if (new Date().getTime() % 2 == 0) {
-                        template.set(path + ".local.SuccessMessage$", "The changes are successfully saved");
-                    } else {
-                        template.set(path + ".local.ErrorMessage$", "Failed to save changes");
-                    }
-                }
-            };
-
-            template.onItemSaveAndClientMessageClick = function (e) {
-                var btn = e.currentTarget;
-                var index = btn.index;
-                var item = btn.item;
-
-                if (!item.local) {
-                    Object.defineProperty(item, "local", {
-                        enumerable: false,
-                        writable: true,
-                        value: {
-                            InfoMessage$: "",
-                            SuccessMessage$: "",
-                            ErrorMessage$: ""
-                        }
-                    });
-                }
-
-                template.set("model.Items." + index + ".SaveAndClientMessageTrigger$", item.SaveAndClientMessageClick$ + 1);
-            };
-        })();
-    </script>
     <template is="declarative-shadow-dom">
         <slot name="kitchensink/callback-heading"></slot>
         <slot name="kitchensink/callback-description"></slot>
@@ -202,13 +87,7 @@
         <slot name="kitchensink/callback-save-server-heading"></slot>
         <slot name="kitchensink/callback-save-server-message"></slot>
         <slot name="kitchensink/callback-save-server-button"></slot>
-        <slot name="kitchensink/callback-save-client-heading"></slot>
-        <slot name="kitchensink/callback-save-client-note"></slot>
-        <slot name="kitchensink/callback-save-client-message"></slot>
 
-        <p>
-            <slot name="kitchensink/callback-save-client-button"></slot>
-        </p>
         <slot name="kitchensink/callback-table-heading"></slot>
         <slot name="kitchensink/callback-table-note"></slot>
         <slot name="kitchensink/callback-table"></slot>

--- a/src/KitchenSink/wwwroot/KitchenSink/CallbackPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/CallbackPage.html
@@ -1,115 +1,108 @@
 <template>
-    <dom-bind><template is="dom-bind">
-        <h1 slot="kitchensink/callback-heading">Async Response</h1>
+    <dom-bind>
+        <template is="dom-bind">
+            <h1 slot="kitchensink/callback-heading">Async Response</h1>
 
-        <p slot="kitchensink/callback-description">
-            This page demonstrates how to achive old fassion <code>callback</code> behaviour using Starcounter.
-        </p>
+            <p slot="kitchensink/callback-description">
+                This page demonstrates how to achive old fassion <code>callback</code> behaviour using Starcounter.
+            </p>
 
-        <h2 slot="kitchensink/callback-responsive-label">Responsive save button</h2>
-        <button slot="kitchensink/callback-responsive-button" type="button" value="{{model.SaveTrigger$::click}}" disabled="{{model.SaveTrigger$}}" onmouseup="++this.value;">Save changes (1s)</button>
-        <button slot="kitchensink/callback-responsive-button-spin" type="button" value="{{model.SaveAndSpinTrigger$::click}}" disabled="{{model.SaveAndSpinTrigger$}}" onmouseup="++this.value;">
-            <template is="dom-if" if="{{model.SaveAndSpinTrigger$}}">
-                <i class="kitchen-sink-spinner">
-                    <svg height="14px" style="enable-background: new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="14px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M28,16c-1.219,0-1.797,0.859-2,1.766C25.269,21.03,22.167,26,16,26c-5.523,0-10-4.478-10-10S10.477,6,16,6  c2.24,0,4.295,0.753,5.96,2H20c-1.104,0-2,0.896-2,2s0.896,2,2,2h6c1.104,0,2-0.896,2-2V4c0-1.104-0.896-2-2-2s-2,0.896-2,2v0.518  C21.733,2.932,18.977,2,16,2C8.268,2,2,8.268,2,16s6.268,14,14,14c9.979,0,14-9.5,14-11.875C30,16.672,28.938,16,28,16z"></path>
+            <h2 slot="kitchensink/callback-responsive-label">Responsive save button</h2>
+            <button slot="kitchensink/callback-responsive-button" type="button" value="{{model.SaveTrigger$::click}}" disabled="{{model.SaveTrigger$}}" onmouseup="++this.value;">Save changes (1s)</button>
+            <button slot="kitchensink/callback-responsive-button-spin" type="button" value="{{model.SaveAndSpinTrigger$::click}}" disabled="{{model.SaveAndSpinTrigger$}}" onmouseup="++this.value;">
+                <template is="dom-if" if="{{model.SaveAndSpinTrigger$}}">
+                    <i class="kitchen-sink-spinner">
+                        <svg height="14px" style="enable-background: new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="14px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M28,16c-1.219,0-1.797,0.859-2,1.766C25.269,21.03,22.167,26,16,26c-5.523,0-10-4.478-10-10S10.477,6,16,6  c2.24,0,4.295,0.753,5.96,2H20c-1.104,0-2,0.896-2,2s0.896,2,2,2h6c1.104,0,2-0.896,2-2V4c0-1.104-0.896-2-2-2s-2,0.896-2,2v0.518  C21.733,2.932,18.977,2,16,2C8.268,2,2,8.268,2,16s6.268,14,14,14c9.979,0,14-9.5,14-11.875C30,16.672,28.938,16,28,16z"></path>
                     </svg>
-                </i>
+                    </i>
+                </template>
+                Save changes with loading icon (1s)
+            </button>
+
+            <h2 slot="kitchensink/callback-save-server-heading">Save button with server side message</h2>
+            <template is="dom-if" if="{{model.SuccessMessage$}}">
+                <p slot="kitchensink/callback-save-server-success-message">{{model.SuccessMessage$}}</p>
             </template>
-            Save changes with loading icon (1s)
-        </button>
+            <template is="dom-if" if="{{model.ErrorMessage$}}">
+                <p slot="kitchensink/callback-save-server-danger-message">{{model.ErrorMessage$}}</p>
+            </template>
+            <button slot="kitchensink/callback-save-server-button" type="button" value="{{model.SaveAndMessageTrigger$::click}}" disabled="{{model.SaveAndMessageTrigger$}}" onmouseup="++this.value;">Randomly save or fail changes (1s)</button>
 
-        <h2 slot="kitchensink/callback-save-server-heading">Save button with server side message</h2>
-        <template is="dom-if" if="{{model.SuccessMessage$}}">
-            <p slot="kitchensink/callback-save-server-success-message">{{model.SuccessMessage$}}</p>
-        </template>
-        <template is="dom-if" if="{{model.ErrorMessage$}}">
-            <p slot="kitchensink/callback-save-server-danger-message">{{model.ErrorMessage$}}</p>
-        </template>
-        <button slot="kitchensink/callback-save-server-button" type="button" value="{{model.SaveAndMessageTrigger$::click}}" disabled="{{model.SaveAndMessageTrigger$}}" onmouseup="++this.value;">Randomly save or fail changes (1s)</button>
-        <h2 slot="kitchensink/callback-save-client-heading">Save button with client side message</h2>
-        <p slot="kitchensink/callback-save-client-note">
-            <b>Note:</b> client side <code>template.observers</code> work only in browsers with native <code>&lt;template&gt;</code> tag implementation.
-        </p>
-
-        <button slot="kitchensink/callback-save-client-button" type="button" value="{{model.SaveAndClientMessageTrigger$::click}}" disabled="{{model.SaveAndClientMessageTrigger$}}" onmouseup="++this.value;">Randomly save or fail changes (1s)</button>
-
-        <h2 slot="kitchensink/callback-table-heading">Same things inside table</h2>
-        <p slot="kitchensink/callback-table-note">
-            <small><b>Note:</b> <code>dom-repeat</code> inside <code>table</code> <a href="https://github.com/Polymer/polymer/issues/1567" target="_blank">does not work in Internet Explorer</a>.</small>
-        </p>
-        <table slot="kitchensink/callback-table">
-            <thead>
-            <tr>
-                <th rowspan="2">#</th>
-                <th>Message</th>
-                <th colspan="2">Responsive button</th>
-                <th>With message</th>
-            </tr>
-            <tr>
-                    <th>Server</th>
-                    <th>Simple</th>
-                    <th>Loading icon</th>
-                    <th>Server</th>
-            </tr>
-            </thead>
-            <tbody>
-            <template is="dom-repeat" items="{{model.Items}}">
-                <tr>
-                    <td>{{index}}</td>
-                    <td>
-                        <template is="dom-if" if="{{item.SuccessMessage$}}">
-                            <span>{{item.SuccessMessage$}}</span>
-                        </template>
-                        <template is="dom-if" if="{{item.ErrorMessage$}}">
-                            <span>{{item.ErrorMessage$}}</span>
-                        </template>
-                    </td>
-                    <td>
-                        <button type="button" value="{{item.SaveTrigger$::click}}" disabled="{{item.SaveTrigger$}}" onmouseup="++this.value;">Save</button>
-                    </td>
-                    <td>
-                        <button type="button" value="{{item.SaveAndSpinTrigger$::click}}" disabled="{{item.SaveAndSpinTrigger$}}" onmouseup="++this.value;">
-                            <template is="dom-if" if="{{item.SaveAndSpinTrigger$}}">
-                                <i class="kitchen-sink-spinner">
-                                    <svg height="14px" style="enable-background: new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="14px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M28,16c-1.219,0-1.797,0.859-2,1.766C25.269,21.03,22.167,26,16,26c-5.523,0-10-4.478-10-10S10.477,6,16,6  c2.24,0,4.295,0.753,5.96,2H20c-1.104,0-2,0.896-2,2s0.896,2,2,2h6c1.104,0,2-0.896,2-2V4c0-1.104-0.896-2-2-2s-2,0.896-2,2v0.518  C21.733,2.932,18.977,2,16,2C8.268,2,2,8.268,2,16s6.268,14,14,14c9.979,0,14-9.5,14-11.875C30,16.672,28.938,16,28,16z"></path>
+            <h2 slot="kitchensink/callback-table-heading">Same things inside table</h2>
+            <p slot="kitchensink/callback-table-note">
+                <small><b>Note:</b> <code>dom-repeat</code> inside <code>table</code> <a href="https://github.com/Polymer/polymer/issues/1567" target="_blank">does not work in Internet Explorer</a>.</small>
+            </p>
+            <table slot="kitchensink/callback-table">
+                <thead>
+                    <tr>
+                        <th rowspan="2">#</th>
+                        <th>Message</th>
+                        <th colspan="2">Responsive button</th>
+                        <th>With message</th>
+                    </tr>
+                    <tr>
+                        <th>Server</th>
+                        <th>Simple</th>
+                        <th>Loading icon</th>
+                        <th>Server</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <template is="dom-repeat" items="{{model.Items}}">
+                        <tr>
+                            <td>{{index}}</td>
+                            <td>
+                                <template is="dom-if" if="{{item.SuccessMessage$}}">
+                                    <span>{{item.SuccessMessage$}}</span>
+                                </template>
+                                <template is="dom-if" if="{{item.ErrorMessage$}}">
+                                    <span>{{item.ErrorMessage$}}</span>
+                                </template>
+                            </td>
+                            <td>
+                                <button type="button" value="{{item.SaveTrigger$::click}}" disabled="{{item.SaveTrigger$}}" onmouseup="++this.value;">Save</button>
+                            </td>
+                            <td>
+                                <button type="button" value="{{item.SaveAndSpinTrigger$::click}}" disabled="{{item.SaveAndSpinTrigger$}}" onmouseup="++this.value;">
+                                    <template is="dom-if" if="{{item.SaveAndSpinTrigger$}}">
+                                        <i class="kitchen-sink-spinner">
+                                            <svg height="14px" style="enable-background: new 0 0 32 32;" version="1.1" viewBox="0 0 32 32" width="14px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><path d="M28,16c-1.219,0-1.797,0.859-2,1.766C25.269,21.03,22.167,26,16,26c-5.523,0-10-4.478-10-10S10.477,6,16,6  c2.24,0,4.295,0.753,5.96,2H20c-1.104,0-2,0.896-2,2s0.896,2,2,2h6c1.104,0,2-0.896,2-2V4c0-1.104-0.896-2-2-2s-2,0.896-2,2v0.518  C21.733,2.932,18.977,2,16,2C8.268,2,2,8.268,2,16s6.268,14,14,14c9.979,0,14-9.5,14-11.875C30,16.672,28.938,16,28,16z"></path>
                                     </svg>
-                                </i>
-                            </template>
-                        </td>
-                        </td>
-                            Save with icon
-                        </button>
-                    </td>
-                    <td>
-                        <button type="button" value="{{item.SaveAndMessageTrigger$::click}}" disabled="{{item.SaveAndMessageTrigger$}}" onmouseup="++this.value;">Save</button>
-                    </td>
-                </tr>
-            </template>
-            </tbody>
-        </table>
-    </template></dom-bind>
-    </script>
-<template is="declarative-shadow-dom">
-    <style>
-        @import "/sys/uniform.css/uniform.css";
-    </style>
-    <slot name="kitchensink/callback-heading"></slot>
-    <slot name="kitchensink/callback-description"></slot>
-    <slot name="kitchensink/callback-responsive-label"></slot>
-    <div>
-        <slot name="kitchensink/callback-responsive-button"></slot>
-        <slot name="kitchensink/callback-responsive-button-spin"></slot>
-    </div>
-    <slot name="kitchensink/callback-save-server-heading"></slot>
-    <div class="uni-alert-success">
-        <slot name="kitchensink/callback-save-server-success-message"></slot>
-    </div>
-    <div class="uni-alert-danger">
-        <slot name="kitchensink/callback-save-server-danger-message"></slot>
-    </div>
-    <slot name="kitchensink/callback-save-server-button"></slot>
-    <slot name="kitchensink/callback-table-heading"></slot>
-    <slot name="kitchensink/callback-table-note"></slot>
-    <slot name="kitchensink/callback-table"></slot>
-</template>
+                                        </i>
+                                    </template>
+                                    Save with icon
+                                </button>
+                            </td>
+                            <td>
+                                <button type="button" value="{{item.SaveAndMessageTrigger$::click}}" disabled="{{item.SaveAndMessageTrigger$}}" onmouseup="++this.value;">Save</button>
+                            </td>
+                        </tr>
+                    </template>
+                </tbody>
+            </table>
+        </template>
+    </dom-bind>
+    <template is="declarative-shadow-dom">
+        <style>
+            @import "/sys/uniform.css/uniform.css";
+        </style>
+        <slot name="kitchensink/callback-heading"></slot>
+        <slot name="kitchensink/callback-description"></slot>
+        <slot name="kitchensink/callback-responsive-label"></slot>
+        <div>
+            <slot name="kitchensink/callback-responsive-button"></slot>
+            <slot name="kitchensink/callback-responsive-button-spin"></slot>
+        </div>
+        <slot name="kitchensink/callback-save-server-heading"></slot>
+        <div class="uni-alert-success">
+            <slot name="kitchensink/callback-save-server-success-message"></slot>
+        </div>
+        <div class="uni-alert-danger">
+            <slot name="kitchensink/callback-save-server-danger-message"></slot>
+        </div>
+        <slot name="kitchensink/callback-save-server-button"></slot>
+        <slot name="kitchensink/callback-table-heading"></slot>
+        <slot name="kitchensink/callback-table-note"></slot>
+        <slot name="kitchensink/callback-table"></slot>
+    </template>
 </template>


### PR DESCRIPTION
**Problem #239:**
Seems like Polymer.Observers are not working now on KitchenSink pages when they are using like `template.observers = [...]`.

**Solution:**
At the moment we decided just remove this example from the CallbackPage.

**Tests:**
I didn't find tests for that page.

**Screenshots:**
_Before merge with Underwear branch:_
![removing_client-side_async_message_with_styles](https://user-images.githubusercontent.com/17431807/36356457-5af8e83a-1503-11e8-9c5b-d9f28af84538.PNG)

_After merge with Underwear branch:_
![removing_client-side_async_message_without_styles](https://user-images.githubusercontent.com/17431807/36356460-679bba18-1503-11e8-9e32-40c6f25a1060.PNG)