### PR TITLE
Problem #273: WaitUntil with error message property.

### DIFF
--- a/test/KitchenSink.Tests/Test/BaseTest.cs
+++ b/test/KitchenSink.Tests/Test/BaseTest.cs
@@ -76,9 +76,9 @@ namespace KitchenSink.Tests.Test
             return string.Join("_", filename.Split(Path.GetInvalidFileNameChars()));
         }
 
-        protected TResult WaitUntil<TResult>(Func<IWebDriver, TResult> condition)
+        protected TResult WaitUntil<TResult>(Func<IWebDriver, TResult> condition, string errorMessage = null)
         {
-            WebDriverWait wait = new WebDriverWait(Driver, TimeSpan.FromSeconds(10));
+            WebDriverWait wait = new WebDriverWait(Driver, TimeSpan.FromSeconds(10)) { Message = errorMessage };
             return wait.Until(condition);
         }
 

--- a/test/KitchenSink.Tests/Test/BaseTest.cs
+++ b/test/KitchenSink.Tests/Test/BaseTest.cs
@@ -76,9 +76,9 @@ namespace KitchenSink.Tests.Test
             return string.Join("_", filename.Split(Path.GetInvalidFileNameChars()));
         }
 
-        protected TResult WaitUntil<TResult>(Func<IWebDriver, TResult> condition, string errorMessage = null)
+        protected TResult WaitUntil<TResult>(Func<IWebDriver, TResult> condition, string errorMessage = null, int timeToWait = 10)
         {
-            WebDriverWait wait = new WebDriverWait(Driver, TimeSpan.FromSeconds(10)) { Message = errorMessage };
+            WebDriverWait wait = new WebDriverWait(Driver, TimeSpan.FromSeconds(timeToWait)) { Message = errorMessage };
             return wait.Until(condition);
         }
 

--- a/test/KitchenSink.Tests/Test/DatepickerPageTest.cs
+++ b/test/KitchenSink.Tests/Test/DatepickerPageTest.cs
@@ -33,9 +33,9 @@ namespace KitchenSink.Tests.Test
             WaitUntil(x => _datePicker.DatePicker.Displayed);
 
             _datePicker.SelectDate("01/01/2016");
-            Assert.AreEqual("2016", _datePicker.YearInput.GetAttribute("value"));
-            Assert.AreEqual("January", _datePicker.MonthInput.GetAttribute("value"));
-            Assert.AreEqual("1", _datePicker.DayInput.GetAttribute("value"));
+            WaitUntil(x => _datePicker.YearInput.GetAttribute("value") == "2016", $"Expected: 2016, but was: {_datePicker.YearInput.GetAttribute("value")}");
+            WaitUntil(x => _datePicker.MonthInput.GetAttribute("value") == "January", $"Expected: January, but was: {_datePicker.MonthInput.GetAttribute("value")}");
+            WaitUntil(x => _datePicker.DayInput.GetAttribute("value") == "1", $"Expected: 1, but was: {_datePicker.DayInput.GetAttribute("value")}");
         }
     }
 }

--- a/test/KitchenSink.Tests/Test/DatepickerPageTest.cs
+++ b/test/KitchenSink.Tests/Test/DatepickerPageTest.cs
@@ -34,8 +34,8 @@ namespace KitchenSink.Tests.Test
 
             _datePicker.SelectDate("01/01/2016");
             WaitUntil(x => _datePicker.YearInput.GetAttribute("value") == "2016", $"Expected: 2016, but was: {_datePicker.YearInput.GetAttribute("value")}");
-            WaitUntil(x => _datePicker.MonthInput.GetAttribute("value") == "January", $"Expected: January, but was: {_datePicker.MonthInput.GetAttribute("value")}");
-            WaitUntil(x => _datePicker.DayInput.GetAttribute("value") == "1", $"Expected: 1, but was: {_datePicker.DayInput.GetAttribute("value")}");
+            StringAssert.AreEqualIgnoringCase("January", _datePicker.MonthInput.GetAttribute("value"));
+            StringAssert.AreEqualIgnoringCase("1", _datePicker.DayInput.GetAttribute("value"));
         }
     }
 }


### PR DESCRIPTION
**Problem #273:**
This PR is the continuation of this comment https://github.com/Starcounter/KitchenSink/pull/270#pullrequestreview-108530843, and it shows what our tests might look like with error message in `WaitUntil`'s.

**Solution:**
Using of error message property in standard WaitUntil was implemented.

**Screenshots:**
_How it looks in VS:_
![image](https://user-images.githubusercontent.com/17431807/38420306-f44d4e6e-39ab-11e8-993e-71e404dc4489.png)

_How it looks in TC:_
![image](https://user-images.githubusercontent.com/17431807/38609431-bad33840-3d86-11e8-89b4-ccd0c046c30a.png)