### PR TITLE
Add page-number click handler back

### DIFF
--- a/src/KitchenSink/wwwroot/KitchenSink/PaginationPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/PaginationPage.html
@@ -38,6 +38,11 @@
             var script = document._currentScript || document.currentScript;
             var template = Polymer.Element ? script.previousElementSibling : script.previousElementSibling.firstElementChild;         
 
+            template.onChangePageClick = function (event) {
+                var span = event.currentTarget;
+                template.set("model.ChangePage$", span.pageNumber);
+            };
+
             template.workaroundPolymerBooleans = function (active) {
                 return active ? "true" : "false";
             };


### PR DESCRIPTION
#277 broke the feature of clicking on the number itself. This fixes it (and the tests).