### PR TITLE
Problem #288: turn off parallel testing.

### DIFF
--- a/test/KitchenSink.Tests/Test/AutoCompletePageTest.cs
+++ b/test/KitchenSink.Tests/Test/AutoCompletePageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/ButtonPageTest.cs
+++ b/test/KitchenSink.Tests/Test/ButtonPageTest.cs
@@ -7,7 +7,6 @@ using OpenQA.Selenium;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/CheckboxPageTest.cs
+++ b/test/KitchenSink.Tests/Test/CheckboxPageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/ClientLocalStatePageTest.cs
+++ b/test/KitchenSink.Tests/Test/ClientLocalStatePageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/DatagridPageTest.cs
+++ b/test/KitchenSink.Tests/Test/DatagridPageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/DatepickerPageTest.cs
+++ b/test/KitchenSink.Tests/Test/DatepickerPageTest.cs
@@ -7,7 +7,6 @@ using OpenQA.Selenium;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/DropdownPageTest.cs
+++ b/test/KitchenSink.Tests/Test/DropdownPageTest.cs
@@ -5,7 +5,6 @@ using OpenQA.Selenium.Support.UI;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/FileUploadPageTest.cs
+++ b/test/KitchenSink.Tests/Test/FileUploadPageTest.cs
@@ -5,7 +5,6 @@ using KitchenSink.Tests.Utilities;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)] //BUG on EDGE https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7194303/
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/MarkdownPageTest.cs
+++ b/test/KitchenSink.Tests/Test/MarkdownPageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]
     class MarkdownPageTest : BaseTest

--- a/test/KitchenSink.Tests/Test/NestedPartialsPageTest.cs
+++ b/test/KitchenSink.Tests/Test/NestedPartialsPageTest.cs
@@ -6,7 +6,6 @@ using OpenQA.Selenium;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/PaginationPageTest.cs
+++ b/test/KitchenSink.Tests/Test/PaginationPageTest.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/PasswordPageTest.cs
+++ b/test/KitchenSink.Tests/Test/PasswordPageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 { 
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/RadioPageTest.cs
+++ b/test/KitchenSink.Tests/Test/RadioPageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/RadiolistPageTest.cs
+++ b/test/KitchenSink.Tests/Test/RadiolistPageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/RedirectPageTest.cs
+++ b/test/KitchenSink.Tests/Test/RedirectPageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/TablePageTest.cs
+++ b/test/KitchenSink.Tests/Test/TablePageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/TextPageTest.cs
+++ b/test/KitchenSink.Tests/Test/TextPageTest.cs
@@ -5,7 +5,6 @@ using OpenQA.Selenium;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/TextareaPageTest.cs
+++ b/test/KitchenSink.Tests/Test/TextareaPageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/ToggleButtonPageTest.cs
+++ b/test/KitchenSink.Tests/Test/ToggleButtonPageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/UrlPageTest.cs
+++ b/test/KitchenSink.Tests/Test/UrlPageTest.cs
@@ -6,7 +6,6 @@ using System.IO;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]

--- a/test/KitchenSink.Tests/Test/ValidationPageTest.cs
+++ b/test/KitchenSink.Tests/Test/ValidationPageTest.cs
@@ -4,7 +4,6 @@ using NUnit.Framework;
 
 namespace KitchenSink.Tests.Test
 {
-    [Parallelizable(ParallelScope.Fixtures)]
     [TestFixture(Config.Browser.Chrome)]
     [TestFixture(Config.Browser.Edge)]
     [TestFixture(Config.Browser.Firefox)]


### PR DESCRIPTION
**Problem #288:** 
As explained in #281 (comment), turn off parallel testing in Selenium.

**Solution:** 
All Parallelizable attributes were removed.

**Tests:**
✅ Tests were passed in 6 minutes, looks good in comparing to 2,5 in average for parallel execution.
