### PR TITLE
Remove non-native `label` attr from `input[type=date]`

### DIFF
--- a/src/KitchenSink/wwwroot/KitchenSink/DatepickerPage.html
+++ b/src/KitchenSink/wwwroot/KitchenSink/DatepickerPage.html
@@ -10,7 +10,6 @@
         <label slot="kitchensink/datepicker-label">Date</label>
         <input slot="kitchensink/datepicker-date"
             type="date"
-            label="Date"
             min="1920-01-01"
             value="{{model.Value$::change}}"
             placeholder="Pick a date"/>


### PR DESCRIPTION
Especially that it's redundant data